### PR TITLE
Fixing breakline combined with expression issue

### DIFF
--- a/Scripts/Toolbox/Editor/DialogueImporter.cs
+++ b/Scripts/Toolbox/Editor/DialogueImporter.cs
@@ -59,7 +59,7 @@ namespace DREditor.Toolbox
 
         // Time to wait before showing the progress
         private double waitForProgress = 0.5;
-        
+        private bool lineBroke = false;
 
         [MenuItem("Tools/DREditor/Import Dialogues")]
         public static void CreateWizard()
@@ -224,8 +224,17 @@ namespace DREditor.Toolbox
                                 // Hook up each part of the dialogue line here
                                 if(lineInfo.expression != null)
                                 {
+                                    if (currentLine >= maxLinesPerDialogue)
+                                    {
+                                        currentLine = 0;
+                                    }
                                     currentDialogue.Lines[currentLine].Expression = lineInfo.expression;
                                     currentDialogue.Lines[currentLine].ExpressionNumber = lineInfo.expressionNumber;
+                                }
+                                if (lineBroke == true)
+                                {
+                                    currentLine++;
+                                    lineBroke = false;
                                 }
                                 if (lineInfo.soundFX != null)
                                 {

--- a/Scripts/Toolbox/Editor/DialogueImporter.cs
+++ b/Scripts/Toolbox/Editor/DialogueImporter.cs
@@ -371,6 +371,7 @@ namespace DREditor.Toolbox
                     if(currentLine.Text.Length + lineLenghtOffset == 0)
                     {
                         currentLine.Text += word;
+                        lineBroke = true;
                         continue;
                     }
                     if(word.Contains("\n"))


### PR DESCRIPTION
The issue was when the current line of dialogue had over the max amount of characters a new Line object was made. If this ever occurred every expression would be in correctly imported. This request fixes the issue and has been tested.