### PR TITLE
Support URP in GetMaterialTexture

### DIFF
--- a/Scripts/Utility/Editor/HandyFields.cs
+++ b/Scripts/Utility/Editor/HandyFields.cs
@@ -142,8 +142,13 @@ namespace DREditor.Utility.Editor
         }
         public static Texture2D GetMaterialTexture(Material material)
         {
-            
-            return material.GetTexture("_MainTex") as Texture2D;
+            return material.GetTexture(
+#if DR_URP
+                "_BaseMap"
+#else
+                "_MainTex"
+#endif
+                ) as Texture2D;
         }
     }
 }


### PR DESCRIPTION
Fan projects that use URP should define `DR_URP` in their project settings.